### PR TITLE
[BUGFIX] Update image tag default display type

### DIFF
--- a/src/components/common/StyledBraftEditor.tsx
+++ b/src/components/common/StyledBraftEditor.tsx
@@ -75,6 +75,7 @@ const OutputMixin = css`
     width: 100%;
     height: auto !important;
     margin-bottom: 1.5rem;
+    display: inline-block;
   }
   iframe {
     width: 100%;


### PR DESCRIPTION
In `braft-editor`, they wrapped `<img>` tag with a `<div>` inline-block in editing mode, so it could align center. 
But when it is displayed in program page, the generated HTML doesn't contain this information, so the image could not be align center.
I updated the img tag default `display` to fix this issue (but I think it's not the best way). 
As `braft-editor` has not been maintained for 3+ years, maybe we need to consider some other packages.

----
### More details
Part of HTML in [editor](https://demo.lodestar-dev.cc/admin/programs/08670731-14e2-45b0-8393-67590555f27c?tab=general)
```
<div draggable="true" class="bf-image" style="text-align: center;">
  <div style="position: relative; width: 661.664px; height: 372px; display: inline-block;">
    <img
      src="https://static-dev.kolable.com/images/demo/editor/ca1c1218-f7a8-4ec0-9cbf-b0668daa0939/1200"
      width="661.6640625"
      height="372"
      id=""
      title=""
      alt=""
      controls=""
      poster=""
    />
    <div class="bf-pre-csize undefined"></div>
  </div>
</div>;
```

In [programs page](https://demo.lodestar-dev.cc/programs/08670731-14e2-45b0-8393-67590555f27c?visitIntro=1), it will display the image with the following HTML:
```
  <div class="media-wrap image-wrap align-center" style="text-align:center">
    <img
      id=""
      title=""
      alt=""
      controls=""
      poster=""
      src="https://static-dev.kolable.com/images/demo/editor/ca1c1218-f7a8-4ec0-9cbf-b0668daa0939/1200"
      width="661.6640625"
      height="372"
      style="width:661.6640625px;height:372px"
    />
  </div>
  <p></p>
```