### PR TITLE
Change: Remove hardcoded block quote align

### DIFF
--- a/src/components/common/StyledBraftEditor.tsx
+++ b/src/components/common/StyledBraftEditor.tsx
@@ -94,7 +94,6 @@ const OutputMixin = css`
     color: #585858;
     font-weight: bold;
     font-style: initial;
-    text-align: center !important;
     transform: translateX(-50%);
 
     @media (min-width: 768px) {


### PR DESCRIPTION
We're going to allow user to edit the block-quote text-align, so remove this hardcoded align