### PR TITLE
fix: resolve cached data in cart

### DIFF
--- a/src/components/modals/CheckoutProductModal.tsx
+++ b/src/components/modals/CheckoutProductModal.tsx
@@ -1,15 +1,5 @@
 import { gql, useQuery } from '@apollo/client'
-import {
-  Box,
-  Button,
-  Checkbox,
-  Divider,
-  OrderedList,
-  SkeletonText,
-  useDisclosure,
-  useToast,
-  Text,
-} from '@chakra-ui/react'
+import { Box, Button, Checkbox, Divider, OrderedList, SkeletonText, useDisclosure, useToast } from '@chakra-ui/react'
 import axios from 'axios'
 import { camelCase } from 'lodash'
 import { now } from 'moment'
@@ -277,11 +267,14 @@ const CheckoutProductModal: React.VFC<CheckoutProductModalProps> = ({
     ...cachedCartInfo.invoice,
   })
 
-  const [payment, setPayment] = useState<PaymentProps | null | undefined>()
-  const [isApproved, setIsApproved] = useState(settings['checkout.approvement'] !== 'true')
+  const [payment, setPayment] = useState<PaymentProps | null | undefined>(memberCartInfo.payment)
+  const [isApproved, setIsApproved] = useState(localStorage.getItem('kolable.checkout.approvement') === 'true')
+
+  // 讓「我同意」按鈕在使用者重新進入後保持一樣
   useEffect(() => {
-    setIsApproved(settings['checkout.approvement'] !== 'true')
-  }, [settings])
+    localStorage.setItem('kolable.checkout.approvement', JSON.stringify(isApproved))
+    setIsApproved(localStorage.getItem('kolable.checkout.approvement') === 'true')
+  }, [isApproved])
 
   useEffect(() => {
     if (currentMember) {
@@ -307,7 +300,7 @@ const CheckoutProductModal: React.VFC<CheckoutProductModalProps> = ({
 
   useEffect(() => {
     if (typeof productTarget?.isSubscription === 'boolean') {
-      setPayment(initialPayment)
+      setPayment(memberCartInfo?.payment)
     }
   }, [productTarget?.isSubscription, initialPayment])
 

--- a/src/components/selectors/PaymentSelector.tsx
+++ b/src/components/selectors/PaymentSelector.tsx
@@ -77,6 +77,9 @@ const PaymentSelector: React.FC<{
     }
   }
 
+  const paymentFromLocalStrorage = localStorage.getItem('kolable.cart.payment.perpetual')
+  const cachedPayment = paymentFromLocalStrorage && JSON.parse(paymentFromLocalStrorage)
+
   return (
     <Form.Item
       className="mb-0"
@@ -100,7 +103,11 @@ const PaymentSelector: React.FC<{
         placeholder={formatMessage(checkoutMessages.label.paymentMethodPlaceholder)}
       >
         {paymentOptions.map(option => (
-          <option key={option.name} value={JSON.stringify(option.payment)}>
+          <option
+            key={option.name}
+            value={JSON.stringify(option.payment)}
+            selected={JSON.stringify(option.payment) === JSON.stringify(cachedPayment)}
+          >
             {option.name}
           </option>
         ))}

--- a/src/components/selectors/PaymentSelector.tsx
+++ b/src/components/selectors/PaymentSelector.tsx
@@ -77,8 +77,8 @@ const PaymentSelector: React.FC<{
     }
   }
 
-  const paymentFromLocalStrorage = localStorage.getItem('kolable.cart.payment.perpetual')
-  const cachedPayment = paymentFromLocalStrorage && JSON.parse(paymentFromLocalStrorage)
+  const paymentFromLocalStorage = localStorage.getItem('kolable.cart.payment.perpetual')
+  const cachedPayment = paymentFromLocalStorage && JSON.parse(paymentFromLocalStorage)
 
   return (
     <Form.Item


### PR DESCRIPTION
1. notice that '付款方式' ‘我同意’ wouldn't keep data after user reload the page.
2. add 'kolable.checkout.approvement' to LocalStorage to store the value.
3. add cachedPage in PaymentSelector.tsx to fix the problem above.