### PR TITLE
bugfix: card-title-fallback

### DIFF
--- a/src/hooks/tracking.ts
+++ b/src/hooks/tracking.ts
@@ -1154,7 +1154,7 @@ export const useMemberShipCardDetails = (memberId: string | undefined) => {
     const cardIdToDatesMap = new Map()
     ;(memberShipCardDetails?.card_enrollment as CwCardEnrollment)?.forEach(cardEnrollment => {
       const cardId = cardEnrollment.card_id
-      const cardTitle = cardEnrollment.card.title
+      const cardTitle = cardEnrollment.card?.title ?? ""
 
       cardEnrollment.member.order_logs.forEach(orderLog => {
         orderLog.order_products.forEach(orderProduct => {


### PR DESCRIPTION
修正當 cardEnrollment.card?.title 為 undefined 時導致錯誤的問題。

- 新增 fallback：當 title 為 undefined 時預設為空字串 ""，避免後續操作錯誤。
- Trello 卡片：https://trello.com/c/jBzBxII1