### PR TITLE
fix(checkout): trigger auth modal on auto-open for unauthenticated users

### DIFF
--- a/src/components/modals/CheckoutProductModal.tsx
+++ b/src/components/modals/CheckoutProductModal.tsx
@@ -141,6 +141,7 @@ export type CheckoutProductModalProps = {
   shippingMethods?: ShippingMethodProps[]
   productQuantity?: number
   isModalDisable?: boolean
+  onAuthRequired?: () => void
   isFieldsValidate?: (fieldsValue: { invoice: InvoiceProps; shipping: ShippingProps }) => {
     isValidInvoice: boolean
     isValidShipping: boolean
@@ -170,6 +171,7 @@ const CheckoutProductModal: React.FC<CheckoutProductModalProps> = ({
   renderTrigger,
   renderProductSelector,
   renderTerms,
+  onAuthRequired,
   setIsModalDisable,
   setIsOrderCheckLoading,
 }) => {
@@ -187,10 +189,15 @@ const CheckoutProductModal: React.FC<CheckoutProductModalProps> = ({
 
   useEffect(() => {
     if (!checkoutOpened.current && checkoutProductId === defaultProductId) {
+      if (isAuthenticating) return
       checkoutOpened.current = true
-      onOpen()
+      if (!currentMemberId && onAuthRequired) {
+        onAuthRequired()
+      } else {
+        onOpen()
+      }
     }
-  }, [checkoutProductId])
+  }, [checkoutProductId, isAuthenticating, currentMemberId])
 
   useEffect(() => {
     if (productQuantity !== undefined) {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -91,27 +91,33 @@ export const AuthProvider: React.FC<{ appId: string }> = ({ appId, children }) =
 
   const refreshToken = useCallback(async () => {
     setIsAuthenticating(true)
-    const fingerPrintId = await getFingerPrintId()
-    const { ip, country, countryCode } = await fetchCurrentGeolocation()
-    const {
-      data: { code, result },
-    } = await Axios.post(
-      `${process.env.REACT_APP_API_BASE_ROOT}/auth/refresh-token`,
-      { appId, fingerPrintId, geoLocation: { ip, country, countryCode } },
-      {
-        method: 'POST',
-        withCredentials: true,
-      },
-    )
-    if (code === 'SUCCESS') {
-      setAuthToken(result.authToken)
-    } else if (code === 'E_NO_DEVICE') {
+    try {
+      const fingerPrintId = await getFingerPrintId()
+      const { ip, country, countryCode } = await fetchCurrentGeolocation()
+      const {
+        data: { code, result },
+      } = await Axios.post(
+        `${process.env.REACT_APP_API_BASE_ROOT}/auth/refresh-token`,
+        { appId, fingerPrintId, geoLocation: { ip, country, countryCode } },
+        {
+          method: 'POST',
+          withCredentials: true,
+        },
+      )
+      if (code === 'SUCCESS') {
+        setAuthToken(result.authToken)
+      } else if (code === 'E_NO_DEVICE') {
+        setAuthToken(null)
+        alert('您已被登出，目前有其他裝置登入這組帳號')
+      } else {
+        setAuthToken(null)
+      }
+    } catch (error) {
+      process.env.NODE_ENV === 'development' && console.error('refresh token failed:', error)
       setAuthToken(null)
-      alert('您已被登出，目前有其他裝置登入這組帳號')
-    } else {
-      setAuthToken(null)
+    } finally {
+      setIsAuthenticating(false)
     }
-    setIsAuthenticating(false)
   }, [appId])
 
   const currentMember = payload && {


### PR DESCRIPTION
When checkoutProductId URL param matches, the useEffect called onOpen() directly. But for unauthenticated users the component returns early without rendering the modal, so nothing happened. Now it checks auth state first and calls onAuthRequired() callback instead, allowing the consumer to show the login modal.

trello card : https://trello.com/c/xb4DSA1r